### PR TITLE
Add CUE-based KG construction use cases

### DIFF
--- a/quicue-compile-time-kg.md
+++ b/quicue-compile-time-kg.md
@@ -1,0 +1,95 @@
+# USE CASE: COMPILE-TIME KNOWLEDGE GRAPH CONSTRUCTION BY QUICUE
+
+## Context
+
+The [apercue.ca](https://github.com/quicue/apercue) project uses
+[CUE](https://cuelang.org) — a constraint language with lattice-based type
+semantics — to construct, validate, and serialize knowledge graphs entirely at
+compile time. Graph building, SHACL validation, and JSON-LD output happen in a
+single `cue export` invocation with no mapping language, no runtime pipeline,
+and no triplestore.
+
+Traditional KG construction requires a multi-stage pipeline:
+
+```
+Source Data → Mapping (R2RML/RML) → RDF Store → SHACL Validation → Serialization
+```
+
+CUE collapses this to:
+
+```
+Source Data (CUE structs) → cue export -e <projection>
+```
+
+The "mapping" is CUE type unification. The "validation" is CUE constraint
+resolution. The "serialization" is JSON-LD context injection. All three happen
+during evaluation — there is no separate step for any of them.
+
+Each resource declares `@type` (a struct-as-set of semantic categories) and
+`depends_on` (typed dependency edges). A `#Graph` pattern computes topology,
+depth, roots, leaves, ancestors, dependents, and impact sets from these
+declarations alone:
+
+```cue
+"analysis-code": {
+    name:       "analysis-code"
+    "@type":    {Process: true}
+    depends_on: {"sensor-dataset": true}
+}
+```
+
+The same typed graph simultaneously produces output in 14 W3C specifications
+(SHACL, PROV-O, OWL-Time, DCAT, ODRL, EARL, SKOS, Dublin Core, JSON-LD,
+schema.org, org, Verifiable Credentials, Activity Streams, and apercue's own
+vocabulary).
+
+## Challenges
+
+1. **Declarative mapping without a mapping language.** R2RML and RML define
+   explicit source-to-target mappings. CUE replaces this with type unification:
+   a resource that satisfies `#Graph.resources[string]` IS a graph node. The
+   mapping is the type constraint itself. This raises questions about how
+   declarative KG construction should be characterized when there is no
+   separate mapping artifact.
+
+2. **Validation as a construction-time guarantee, not a post-hoc check.**
+   SHACL validation typically runs after KG construction. In CUE, constraints
+   are part of the type lattice — an invalid graph cannot be constructed
+   (unification produces bottom `_|_`). The `sh:ValidationReport` is a
+   projection of a graph that has already passed validation by existing at all.
+   This inverts the usual validate-after-construct pattern.
+
+3. **Provenance without a provenance store.** The `#ProvenanceTrace` pattern
+   computes PROV-O output from the dependency structure. `prov:wasDerivedFrom`
+   edges are dependency edges. Provenance is not annotated — it is structurally
+   computed. This challenges the assumption that provenance requires separate
+   recording infrastructure.
+
+4. **Incremental construction via file addition.** Adding a resource means
+   adding a `.cue` file. CUE unification merges it into the existing graph.
+   There is no import step, no migration, no re-indexing. The graph extends
+   by structural composition. This differs from both batch and streaming
+   approaches to KG construction.
+
+5. **Performance ceiling on transitive operations.** CUE does not memoize
+   recursive struct references. Transitive closure (ancestors, dependents,
+   impact sets) becomes exponential on diamond DAGs beyond ~40 nodes,
+   requiring precomputation via external tools. This is a real constraint
+   on the approach.
+
+## Resources
+
+- **Website:** [apercue.ca](https://apercue.ca)
+- **Data:** Five-node research publication pipeline (ethics approval → sensor
+  data → analysis → paper → peer review); 43-node project charter
+  (self-modeling)
+- **Mappings:** CUE type definitions in `vocab/` and `patterns/` packages —
+  ~40 pattern types across 12 files
+- **Ontology:** JSON-LD `@context` mapping CUE fields to Dublin Core, PROV-O,
+  SHACL, SKOS, OWL-Time, DCAT, ODRL, EARL, schema.org, org
+- **Tool(s):** [CUE](https://cuelang.org) v0.15.4, Python toposort for
+  precomputation, D3.js for visualization
+- **Output:** JSON-LD 1.1 with W3C vocabulary terms; SHACL validation reports;
+  PROV-O provenance traces; OWL-Time scheduling intervals; DCAT catalogs
+- **Source code:** [github.com/quicue/apercue](https://github.com/quicue/apercue) (Apache 2.0)
+- **Full evidence:** [W3C core report](https://github.com/quicue/apercue/blob/main/w3c/core-report.md) — 14 specs, computed JSON evidence

--- a/quicue-compile-time-kg.md
+++ b/quicue-compile-time-kg.md
@@ -81,7 +81,7 @@ vocabulary).
 
 - **Website:** [apercue.ca](https://apercue.ca)
 - **Data:** Five-node research publication pipeline (ethics approval → sensor
-  data → analysis → paper → peer review); 43-node project charter
+  data → analysis → paper → peer review); 41-node project charter
   (self-modeling)
 - **Mappings:** CUE type definitions in `vocab/` and `patterns/` packages —
   63 pattern definitions across 13 files

--- a/quicue-compile-time-kg.md
+++ b/quicue-compile-time-kg.md
@@ -84,7 +84,7 @@ vocabulary).
   data → analysis → paper → peer review); 43-node project charter
   (self-modeling)
 - **Mappings:** CUE type definitions in `vocab/` and `patterns/` packages —
-  ~40 pattern types across 12 files
+  63 pattern definitions across 13 files
 - **Ontology:** JSON-LD `@context` mapping CUE fields to Dublin Core, PROV-O,
   SHACL, SKOS, OWL-Time, DCAT, ODRL, EARL, schema.org, org
 - **Tool(s):** [CUE](https://cuelang.org) v0.15.4, Python toposort for

--- a/quicue-project-scheduling-kg.md
+++ b/quicue-project-scheduling-kg.md
@@ -67,7 +67,7 @@ completion.
 
 - **Website:** [apercue.ca](https://apercue.ca)
 - **Data:** Five-node research pipeline (CPM: 285-day duration, 0 slack);
-  43-node self-charter (8 phase gates, all satisfied)
+  41-node self-charter (8 phase gates, all satisfied)
 - **Mappings:** `#Charter`, `#GapAnalysis`, `#CriticalPath`,
   `#CriticalPathPrecomputed`, `#SinglePointsOfFailure` in `patterns/` package
 - **Ontology:** OWL-Time (`time:Interval`, `time:Duration`, `time:Instant`),

--- a/quicue-project-scheduling-kg.md
+++ b/quicue-project-scheduling-kg.md
@@ -1,0 +1,81 @@
+# USE CASE: PROJECT SCHEDULING KNOWLEDGE GRAPHS BY QUICUE
+
+## Context
+
+The [apercue.ca](https://github.com/quicue/apercue) project implements project
+scheduling — critical path method (CPM), milestone evaluation, gap analysis, and
+test planning — as CUE type constraints that produce a knowledge graph.
+
+A `#Charter` declares required resources, types, and completion gates. A
+`#GapAnalysis` pattern unifies the charter against a `#Graph` and computes what
+is missing. `cue vet` fails if the project is incomplete. The result is a
+scheduling KG where project management concerns (milestones, dependencies,
+slack, critical path) are W3C vocabulary terms, not proprietary fields.
+
+```cue
+#Charter: {
+    scope: {
+        total_resources:    int
+        required_resources: {[string]: true}
+        required_types:     {[string]: true}
+    }
+    gates: [...#Gate]
+}
+```
+
+The same 5-node research publication pipeline used across all apercue
+submissions produces a 285-day critical path with forward/backward scheduling
+passes, OWL-Time interval output, and SHACL validation reports for gate
+completion.
+
+## Challenges
+
+1. **Encoding scheduling as a knowledge graph, not alongside one.** Project
+   schedules are typically stored in proprietary formats (MS Project, Jira) and
+   optionally linked to KGs. In CUE, the schedule IS the graph — each resource
+   has `time:hasBeginning`, `time:hasEnd`, `time:hasDuration` as OWL-Time
+   intervals, plus `apercue:slack` and `apercue:isCritical` extensions.
+   Critical path computation is a graph traversal, not a separate tool.
+
+2. **Gap analysis as constraint violation.** A gate requiring
+   `{sensor-dataset: true, ethics-approval: true}` is a set membership check.
+   Missing resources produce `sh:conforms: false`. This means project
+   incompleteness is a SHACL validation failure — the same mechanism used for
+   data quality in standard KG validation. The question: should KG-Construct
+   consider project management artifacts as a KG construction target?
+
+3. **Multi-domain scheduling from a single pattern.** The same `#CriticalPath`
+   pattern has been applied to research data management (5 nodes), IT
+   infrastructure (30 nodes), university curricula (12 courses), and
+   construction project management (18 work packages). The pattern is
+   domain-agnostic — only the resource declarations change. This suggests
+   scheduling KGs are a reusable construction pattern, not a domain-specific
+   application.
+
+4. **EARL test reports from smoke test definitions.** Test plans produce
+   `earl:Assertion` entries with `earl:passed` / `earl:failed` outcomes.
+   Smoke tests defined in CUE become part of the scheduling KG — they are
+   resources with dependencies, durations, and critical path positions.
+   Testing infrastructure becomes part of the project graph.
+
+5. **Performance ceiling.** As with all apercue patterns, CPM recursive
+   fixpoint computation times out on graphs exceeding ~38 nodes. The
+   `#CriticalPathPrecomputed` variant uses Python-precomputed topology to
+   work around this CUE evaluation constraint.
+
+## Resources
+
+- **Website:** [apercue.ca](https://apercue.ca)
+- **Data:** Five-node research pipeline (CPM: 285-day duration, 0 slack);
+  43-node self-charter (8 phase gates, all satisfied)
+- **Mappings:** `#Charter`, `#GapAnalysis`, `#CriticalPath`,
+  `#CriticalPathPrecomputed`, `#SinglePointsOfFailure` in `patterns/` package
+- **Ontology:** OWL-Time (`time:Interval`, `time:Duration`, `time:Instant`),
+  SHACL (`sh:ValidationReport`), EARL (`earl:Assertion`), Dublin Core
+  (`dcterms:requires`)
+- **Tool(s):** [CUE](https://cuelang.org) v0.15.4, Python toposort for
+  precomputation, D3.js for Gantt and graph visualization
+- **Output:** OWL-Time scheduling intervals; SHACL gate-completion reports;
+  EARL test assertions; CPM summary (critical path, slack, duration)
+- **Source code:** [github.com/quicue/apercue](https://github.com/quicue/apercue) (Apache 2.0)
+- **Full evidence:** [W3C core report](https://github.com/quicue/apercue/blob/main/w3c/core-report.md)


### PR DESCRIPTION
## Summary

Two use cases demonstrating CUE as a declarative KG construction language:

- **quicue-compile-time-kg.md** — CUE type unification as declarative mapping, with SHACL validation as a construction-time guarantee and JSON-LD via `@context` injection. The entire KG construction pipeline (mapping, validation, serialization) collapses to a single `cue export` invocation.

- **quicue-project-scheduling-kg.md** — Project scheduling as a KG construction target. Critical path method, milestone gates, and gap analysis produce OWL-Time intervals, SHACL gate-completion reports, and EARL test assertions from the same typed dependency graph.

Both follow the `basic-template.md` format (Context / Challenges / Resources).

## Evidence

A single 5-node graph produces output in 14 W3C specifications. Full computed JSON evidence: [W3C core report](https://github.com/quicue/apercue/blob/main/w3c/core-report.md)

Source: [github.com/quicue/apercue](https://github.com/quicue/apercue) (Apache 2.0)